### PR TITLE
Allow isPaused to be set via Update API

### DIFF
--- a/models/check.js
+++ b/models/check.js
@@ -317,7 +317,7 @@ Check.methods.getSingleStatForPeriod = function(period, date, callback) {
 Check.methods.populateFromDirtyCheck = function(dirtyCheck, pollerCollection) {
   this.url = dirtyCheck.url || this.url;
   this.maxTime = dirtyCheck.maxTime || this.maxTime;
-  this.isPaused = dirtyCheck.isPaused || this.isPaused;
+  this.isPaused = (dirtyCheck.isPaused == undefined) ? this.isPaused : dirtyCheck.isPaused
   this.alertTreshold = dirtyCheck.alertTreshold || this.alertTreshold;
   this.interval = dirtyCheck.interval * 1000 || this.interval;
 


### PR DESCRIPTION
This allows the isPaused attribute to be set when calling
POST /checks/:id

Fixes #316